### PR TITLE
Added ModifierType::Both to do ModifierAction for both Local and Global grid sizes

### DIFF
--- a/source/enum/modifier_type.h
+++ b/source/enum/modifier_type.h
@@ -21,7 +21,11 @@ enum class ModifierType
 
     /** Parameter value affects local thread size of corresponding kernel.
       */
-    Local
+    Local,
+
+    /** Parameter value affects both global and local thread size of corresponding kernel.
+      */
+    Both
 };
 
 } // namespace ktt

--- a/source/kernel/kernel_manager.cpp
+++ b/source/kernel/kernel_manager.cpp
@@ -100,6 +100,10 @@ KernelConfiguration KernelManager::getKernelConfiguration(const KernelId id, con
                 {
                     local.modifyByValue(parameterPair.getValue(), parameter.getModifierAction(), parameter.getModifierDimension());
                 }
+                else if (parameter.getModifierType() == ModifierType::Both) {
+                    local.modifyByValue(parameterPair.getValue(), parameter.getModifierAction(), parameter.getModifierDimension());
+                    global.modifyByValue(parameterPair.getValue(), parameter.getModifierAction(), parameter.getModifierDimension());
+                }
 
                 if (parameter.isLocalMemoryModifier())
                 {
@@ -156,7 +160,7 @@ KernelConfiguration KernelManager::getKernelCompositionConfiguration(const Kerne
                 {
                     for (const auto kernelId : parameter.getCompositionKernels())
                     {
-                        if (globalSizePair.first == kernelId && parameter.getModifierType() == ModifierType::Global)
+                        if (globalSizePair.first == kernelId && (parameter.getModifierType() == ModifierType::Global || parameter.getModifierType() == ModifierType::Both))
                         {
                             globalSizePair.second.modifyByValue(parameterPair.getValue(), parameter.getModifierAction(),
                                 parameter.getModifierDimension());
@@ -167,7 +171,7 @@ KernelConfiguration KernelManager::getKernelCompositionConfiguration(const Kerne
                 {
                     for (const auto kernelId : parameter.getCompositionKernels())
                     {
-                        if (localSizePair.first == kernelId && parameter.getModifierType() == ModifierType::Local)
+                        if (localSizePair.first == kernelId && (parameter.getModifierType() == ModifierType::Local || parameter.getModifierType() == ModifierType::Both))
                         {
                             localSizePair.second.modifyByValue(parameterPair.getValue(), parameter.getModifierAction(),
                                 parameter.getModifierDimension());
@@ -502,6 +506,11 @@ void KernelManager::computeConfigurations(const KernelId kernelId, const size_t 
             {
                 newLocalSize.modifyByValue(value, parameter.getModifierAction(), parameter.getModifierDimension());
             }
+            else if (parameter.getModifierType() == ModifierType::Both)
+            {
+                newGlobalSize.modifyByValue(value, parameter.getModifierAction(), parameter.getModifierDimension());
+                newLocalSize.modifyByValue(value, parameter.getModifierAction(), parameter.getModifierDimension());
+            }
 
             std::vector<LocalMemoryModifier> newModifiers = modifiers;
             if (parameter.isLocalMemoryModifier())
@@ -564,7 +573,7 @@ void KernelManager::computeCompositionConfigurations(const size_t currentParamet
             {
                 for (auto& globalSizePair : newGlobalSizes)
                 {
-                    if (compositionKernelId == globalSizePair.first && parameter.getModifierType() == ModifierType::Global)
+                    if (compositionKernelId == globalSizePair.first && (parameter.getModifierType() == ModifierType::Global || parameter.getModifierType() == ModifierType::Both))
                     {
                         globalSizePair.second.modifyByValue(value, parameter.getModifierAction(), parameter.getModifierDimension());
                     }
@@ -572,7 +581,7 @@ void KernelManager::computeCompositionConfigurations(const size_t currentParamet
 
                 for (auto& localSizePair : newLocalSizes)
                 {
-                    if (compositionKernelId == localSizePair.first && parameter.getModifierType() == ModifierType::Local)
+                    if (compositionKernelId == localSizePair.first && (parameter.getModifierType() == ModifierType::Local || parameter.getModifierType() == ModifierType::Both))
                     {
                         localSizePair.second.modifyByValue(value, parameter.getModifierAction(), parameter.getModifierDimension());
                     }


### PR DESCRIPTION
KTT currently lacks the option to modify (e.g. divide) both global and local grid size by a parameter. I need it for a new example I am working on (parameterized fused kernel for BiCG), so I added `ModifierType::Both` to do the job.

It may still not be enough for some problems, one parameter should be able to modify different `ModifierDimension` with different `ModifierAction` for either Global or Local grid (`ModifierType`), so it may be wise to rework the `addParameter()` fuction to use vectors of these.