### PR TITLE
BiCG (Biconjugate gradients method) example

### DIFF
--- a/examples/bicg/bicg.cpp
+++ b/examples/bicg/bicg.cpp
@@ -1,0 +1,265 @@
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+#include "tuner_api.h"
+
+#if defined(_MSC_VER)
+#define KTT_KERNEL_FILE "../examples/bicg/bicg_kernel.cl"
+#define KTT_REFERENCE_KERNEL_FILE "../examples/bicg/bicg_reference_kernel.cl"
+#else
+#define KTT_KERNEL_FILE "../../examples/bicg/bicg_kernel.cl"
+#define KTT_REFERENCE_KERNEL_FILE "../../examples/bicg/bicg_reference_kernel.cl"
+#endif
+
+/* Problem size. */
+#define N 16384
+#define M 8192
+
+/* Thread block dimensions */
+#define WORK_GROUP_X 256
+#define WORK_GROUP_Y 1
+
+// New NVidia GPUs have max. workgroup size of 1024
+#define MAX_WORK_GROUP_SIZE 1024
+
+class BicgCpu : public ktt::ReferenceClass
+{
+public:
+	BicgCpu(const ktt::ArgumentId arg1Id, const ktt::ArgumentId arg2Id, const std::vector<float>& A, const std::vector<float>& x1, const std::vector<float>& x2, const std::vector<float>& y1, const std::vector<float>& y2) :
+		arg1Id(arg1Id),
+		arg2Id(arg2Id),
+		A(A),
+		x1(x1),
+		x2(x2),
+		y1(y1),
+		y2(y2)
+	{}
+
+	// Method inherited from ReferenceClass, which computes reference result for all arguments that are validated inside the class.
+	void computeResult() override
+	{
+		int i, j;
+
+		for (i = 0; i < M; i++)
+		{
+			y2[i] = 0.0;
+		}
+
+		for (i = 0; i < N; i++)
+		{
+			y1[i] = 0.0;
+			for (j = 0; j < M; j++)
+			{
+				y2[j] = y2[j] + x2[i] * A[i*M + j];
+				y1[i] = y1[i] + A[i*M + j] * x1[j];
+			}
+		}
+	}
+
+	// Method inherited from ReferenceClass, which returns memory location where reference result for corresponding argument is stored.
+	void* getData(const ktt::ArgumentId id) override
+	{
+		if (id == arg1Id)
+		{
+			return y1.data();
+		}
+		if (id == arg2Id)
+		{
+			return y2.data();
+		}
+		return nullptr;
+	}
+
+private:
+	ktt::ArgumentId arg1Id;
+	ktt::ArgumentId arg2Id;
+	const std::vector<float>& A;
+	const std::vector<float>& x1;
+	const std::vector<float>& x2;
+	std::vector<float> y1;
+	std::vector<float> y2;
+};
+
+class BicgManipulator : public ktt::TuningManipulator
+{
+public:
+	BicgManipulator(const ktt::KernelId kernel1Id, const ktt::KernelId kernel2Id, const ktt::KernelId kernelFusedId, const ktt::KernelId kernelFusedRefId, const ktt::KernelId kernelReduction1Id, const ktt::KernelId kernelReduction2Id) :
+		kernel1Id(kernel1Id),
+		kernel2Id(kernel2Id),
+		kernelFusedId(kernelFusedId),
+		kernelFusedRefId(kernelFusedRefId),
+		kernelReduction1Id(kernelReduction1Id),
+		kernelReduction2Id(kernelReduction2Id)
+	{}
+
+	// LaunchComputation is responsible for actual execution of tuned kernel
+	void launchComputation(const ktt::KernelId kernelId) override
+	{
+		std::vector<ktt::ParameterPair> parameterValues = getCurrentConfiguration();
+
+		if (getParameterValue("FUSED", parameterValues) == 2) {
+			ktt::DimensionVector globalSize = getCurrentGlobalSize(kernelFusedId);
+			ktt::DimensionVector localSize = getCurrentLocalSize(kernelFusedId);
+
+			const int rowsProcessed = getParameterValue("ROWS_PROCESSED", parameterValues);
+			const int tile = getParameterValue("TILE", parameterValues);
+			const int bicgBatch = getParameterValue("BICG_BATCH", parameterValues);
+			globalSize.setSizeX(M);
+			globalSize.setSizeY(N / rowsProcessed * tile / bicgBatch);
+			localSize.setSizeX(tile);
+			localSize.setSizeY(tile / bicgBatch);
+			printf("changed global to %d x %d and local to %d x %d\n", globalSize.getSizeX(), globalSize.getSizeY(), localSize.getSizeX(), localSize.getSizeY());
+
+			runKernel(kernelFusedId, globalSize, localSize);
+			if (getParameterValue("ATOMICS", parameterValues) == 0) {
+				runKernel(kernelReduction1Id);
+				runKernel(kernelReduction2Id);
+			}
+		}
+		else if (getParameterValue("FUSED", parameterValues) == 1) {
+			runKernel(kernelFusedRefId);
+		}
+		else {
+			runKernel(kernel1Id);
+			runKernel(kernel2Id);
+		}
+	}
+
+private:
+	ktt::KernelId kernel1Id;
+	ktt::KernelId kernel2Id;
+	ktt::KernelId kernelFusedId;
+	ktt::KernelId kernelFusedRefId;
+	ktt::KernelId kernelReduction1Id;
+	ktt::KernelId kernelReduction2Id;
+};
+
+int main(int argc, char** argv)
+{
+	// Initialize platform index, device index and paths to kernels
+	ktt::PlatformIndex platformIndex = 0;
+	ktt::DeviceIndex deviceIndex = 0;
+	std::string kernelFile = KTT_KERNEL_FILE;
+	std::string referenceKernelFile = KTT_REFERENCE_KERNEL_FILE;
+
+	if (argc >= 2)
+	{
+		platformIndex = std::stoul(std::string(argv[1]));
+		if (argc >= 3)
+		{
+			deviceIndex = std::stoul(std::string(argv[2]));
+			if (argc >= 4)
+			{
+				kernelFile = std::string(argv[3]);
+				if (argc >= 5)
+				{
+					referenceKernelFile = std::string(argv[4]);
+				}
+			}
+		}
+	}
+
+	// Declare kernel parameters
+	const ktt::DimensionVector ndRangeDimensions(M, N / 64); // replaced in manipulator
+	const ktt::DimensionVector workGroupDimensions(32, 4); // replaced in manipulator
+	const ktt::DimensionVector referenceNdRangeDimensions1(ceil(N / WORK_GROUP_X)*WORK_GROUP_X, 1);
+	const ktt::DimensionVector referenceNdRangeDimensions2(ceil(M / WORK_GROUP_X)*WORK_GROUP_X, 1);
+	const ktt::DimensionVector referenceWorkGroupDimensions(WORK_GROUP_X, 1);
+
+	// Declare data variables
+	std::vector<float> A(N * M);
+	std::vector<float> x1(M);
+	std::vector<float> x2(N);
+	// larger versions of vectors needed for ATOMICS == 0, they are reduced later in separate kernels
+	std::vector<float> y1(N * M/16, 0.0f); // 16 is the lowest TILE size, so M/16 is maximum number of x-blocks
+	std::vector<float> y2(M * N/128, 0.0f); // 128 is the lowest ROWS_PROCESSED value, so N/128 is maximum number of y-blocks
+
+	// Initialize data
+	std::random_device device;
+	std::default_random_engine engine(device());
+	std::uniform_real_distribution<float> distribution(0.0f, 100.0f);
+
+	for (int j = 0; j < M; j++)
+		x1[j] = distribution(engine);
+	for (int i = 0; i < N; i++) {
+		x2[i] = distribution(engine);
+		for (int j = 0; j < M; j++)
+			A[i*M + j] = distribution(engine);
+	}
+
+	// Create tuner object for specified platform and device
+	ktt::Tuner tuner(platformIndex, deviceIndex);
+
+	// Add all arguments utilized by kernels
+	ktt::ArgumentId AId = tuner.addArgumentVector(A, ktt::ArgumentAccessType::ReadOnly);
+	ktt::ArgumentId x1Id = tuner.addArgumentVector(x1, ktt::ArgumentAccessType::ReadOnly);
+	ktt::ArgumentId x2Id = tuner.addArgumentVector(x2, ktt::ArgumentAccessType::ReadOnly);
+	ktt::ArgumentId y1Id = tuner.addArgumentVector(y1, ktt::ArgumentAccessType::ReadWrite);
+	ktt::ArgumentId y2Id = tuner.addArgumentVector(y2, ktt::ArgumentAccessType::ReadWrite);
+	ktt::ArgumentId mFusedRefId = tuner.addArgumentScalar(M);
+	ktt::ArgumentId nFusedRefId = tuner.addArgumentScalar(256);
+	ktt::ArgumentId mRefId = tuner.addArgumentScalar(M);
+	ktt::ArgumentId nRefId = tuner.addArgumentScalar(N);
+
+	// Add kernels to tuner, create a kernel composition
+	ktt::KernelId kernelFusedId = tuner.addKernelFromFile(kernelFile, "bicgFused", ndRangeDimensions, workGroupDimensions);
+	ktt::KernelId kernelReduction1Id = tuner.addKernelFromFile(kernelFile, "bicgReduction1", referenceNdRangeDimensions1, referenceWorkGroupDimensions);
+	ktt::KernelId kernelReduction2Id = tuner.addKernelFromFile(kernelFile, "bicgReduction2", referenceNdRangeDimensions1, referenceWorkGroupDimensions);
+	ktt::KernelId kernelFusedRefId = tuner.addKernelFromFile(referenceKernelFile, "bicgFusedRef", ndRangeDimensions, workGroupDimensions);
+	ktt::KernelId kernel1Id = tuner.addKernelFromFile(referenceKernelFile, "bicgKernel1", referenceNdRangeDimensions1, referenceWorkGroupDimensions);
+	ktt::KernelId kernel2Id = tuner.addKernelFromFile(referenceKernelFile, "bicgKernel2", referenceNdRangeDimensions2, referenceWorkGroupDimensions);
+	ktt::KernelId kernelId = tuner.addComposition("BicgPolyBenchAndFused", std::vector<ktt::KernelId>{kernel1Id, kernel2Id, kernelFusedId, kernelFusedRefId, kernelReduction1Id, kernelReduction2Id}, std::make_unique<BicgManipulator>(kernel1Id, kernel2Id, kernelFusedId, kernelFusedRefId, kernelReduction1Id, kernelReduction2Id));
+	
+	// Add parameters to tuned kernel
+	tuner.addParameter(kernelId, "FUSED", std::vector<size_t>{ 0, 1, 2 });
+	tuner.addParameter(kernelId, "BICG_BATCH", std::vector<size_t>{ 1, 2, 4, 8 });
+	tuner.addParameter(kernelId, "USE_SHARED_MATRIX", std::vector<size_t>{ 0, 1 });
+	tuner.addParameter(kernelId, "USE_SHARED_VECTOR_1", std::vector<size_t>{ 0, 1 });
+	tuner.addParameter(kernelId, "USE_SHARED_VECTOR_2", std::vector<size_t>{ 0, 1 });
+	tuner.addParameter(kernelId, "USE_SHARED_REDUCTION_1", std::vector<size_t>{ 0, 1 });
+	tuner.addParameter(kernelId, "USE_SHARED_REDUCTION_2", std::vector<size_t>{ 0, 1 });
+	tuner.addParameter(kernelId, "ATOMICS", std::vector<size_t>{ 0, 1 });
+	tuner.addParameter(kernelId, "UNROLL_BICG_STEP", std::vector<size_t>{ 0, 1 });
+	tuner.addParameter(kernelId, "ROWS_PROCESSED", std::vector<size_t>{ 128, 256, 512, 1024 });
+	tuner.addParameter(kernelId, "TILE", std::vector<size_t>{ 16, 32, 64 });
+
+	// Specify contraints
+	// All of the parameters are used only in the fused kernel
+	auto fused = [](std::vector<size_t> vector) {return vector.at(0) == 2 || ((vector.at(0) == 0 || vector.at(0) == 1) && vector.at(1) == 4 && vector.at(2) == 1 && vector.at(3) == 1 && vector.at(4) == 1 && vector.at(5) == 1 && vector.at(6) == 1 && vector.at(7) == 1 && vector.at(8) == 1 && vector.at(9) == 512 && vector.at(10) == 32); };
+	tuner.addConstraint(kernelId, fused, std::vector<std::string>{"FUSED", "BICG_BATCH", "USE_SHARED_MATRIX", "USE_SHARED_VECTOR_1", "USE_SHARED_VECTOR_2", "USE_SHARED_REDUCTION_1", "USE_SHARED_REDUCTION_2", "ATOMICS", "UNROLL_BICG_STEP", "ROWS_PROCESSED", "TILE"});
+	// New NVidia GPUs have max. workgroup size of 1024, so   tile_x * tile_y <= 1024   ==>   tile_x * (tile_x / batch) <= 1024
+	auto maxWgSize = [](std::vector<size_t> vector) {return vector.at(0) * vector.at(0) / vector.at(1) <= MAX_WORK_GROUP_SIZE; };
+	tuner.addConstraint(kernelId, maxWgSize, std::vector<std::string>{"TILE", "BICG_BATCH"});
+
+	// Set kernel arguments for both tuned kernel and reference kernel, order of arguments is important
+	tuner.setCompositionKernelArguments(kernelId, kernelFusedId, { AId, x1Id, y1Id, x2Id, y2Id, mRefId, nRefId });
+	tuner.setCompositionKernelArguments(kernelId, kernelReduction1Id, std::vector<ktt::ArgumentId>{mRefId, nRefId, y1Id});
+	tuner.setCompositionKernelArguments(kernelId, kernelReduction2Id, std::vector<ktt::ArgumentId>{mRefId, nRefId, y2Id});
+	tuner.setCompositionKernelArguments(kernelId, kernelFusedRefId, { AId, x2Id, y2Id, x1Id, y1Id, nFusedRefId, mFusedRefId }); // reference fused kernel uses swapped M and N. same for x1/x2 and y1/y2
+	tuner.setCompositionKernelArguments(kernelId, kernel1Id, std::vector<ktt::ArgumentId>{AId, x1Id, y1Id, mRefId, nRefId});
+	tuner.setCompositionKernelArguments(kernelId, kernel2Id, std::vector<ktt::ArgumentId>{AId, x2Id, y2Id, mRefId, nRefId});
+
+	// Set search method to random search, only 10% of all configurations will be explored.
+	//tuner.setSearchMethod(ktt::SearchMethod::RandomSearch, std::vector<double>{0.1});
+
+	// Specify custom tolerance threshold for validation of floating point arguments. Default threshold is 1e-4.
+	tuner.setValidationMethod(ktt::ValidationMethod::SideBySideRelativeComparison, 0.001);
+	tuner.setValidationRange(y1Id, N);
+	tuner.setValidationRange(y2Id, M);
+
+	// Set tuning manipulator, which implements custom method for launching the kernel
+	tuner.setTuningManipulator(kernelId, std::make_unique<BicgManipulator>(kernel1Id, kernel2Id, kernelFusedId, kernelFusedRefId, kernelReduction1Id, kernelReduction2Id));
+
+	// Set reference kernel which validates results provided by tuned kernel, provide list of arguments which will be validated
+	tuner.setReferenceClass(kernelId, std::make_unique<BicgCpu>(y1Id, y2Id, A, x1, x2, y1, y2), std::vector<ktt::ArgumentId>{y1Id, y2Id});
+
+	// Launch kernel tuning
+	tuner.tuneKernel(kernelId);
+
+	// Print tuning results to standard output and to output.csv file
+	tuner.printResult(kernelId, std::cout, ktt::PrintFormat::Verbose);
+	tuner.printResult(kernelId, "bicg_output.csv", ktt::PrintFormat::CSV);
+
+	return 0;
+}

--- a/examples/bicg/bicg_kernel.cl
+++ b/examples/bicg/bicg_kernel.cl
@@ -1,0 +1,322 @@
+/**
+ * bicg.cl: This file is part of the PolyBench/GPU 1.0 test suite.
+ *
+ *
+ * Contact: Scott Grauer-Gray <sgrauerg@gmail.com>
+ * Louis-Noel Pouchet <pouchet@cse.ohio-state.edu>
+ * Web address: http://www.cse.ohio-state.edu/~pouchet/software/polybench/GPU
+ */
+
+// process BICG_BATCH elements in thread
+#define BICG_STEP TILE/BICG_BATCH
+
+__kernel void bicgKernel1(__global float *A, __global float *p, __global float *q, int nx, int ny)
+{
+	int i = get_global_id(0);
+
+	if (i < nx)
+	{
+		q[i] = 0.0;
+
+		int j;
+		for (j = 0; j < ny; j++)
+		{
+			q[i] += A[i * ny + j] * p[j];
+		}
+	}
+}
+
+__kernel void bicgKernel2(__global float *A, __global float *r, __global float *s, int nx, int ny)
+{
+	int j = get_global_id(0);
+
+	if (j < ny)
+	{
+		s[j] = 0.0;
+
+		int i;
+		for (i = 0; i < nx; i++)
+		{
+			s[j] += A[i * ny + j] * r[i];
+		}
+	}
+}
+
+inline void atomicAdd_g_f(volatile __global float *addr, float val)
+{
+	union {
+		unsigned int u32;
+		float f32;
+	} next, expected, current;
+	current.f32 = *addr;
+	do {
+		expected.f32 = current.f32;
+		next.f32 = expected.f32 + val;
+		current.u32 = atomic_cmpxchg((volatile __global unsigned int *)addr,
+			expected.u32, next.u32);
+	} while (current.u32 != expected.u32);
+}
+
+inline void barrier_sh_red() {
+#if USE_SHARED_REDUCTION_2 == 1
+	barrier(CLK_LOCAL_MEM_FENCE);
+#else
+	barrier(CLK_GLOBAL_MEM_FENCE);
+#endif
+}
+
+__kernel void bicgReduction1(int m, int n, __global float *y1) {
+	int id = get_global_id(0);
+	if (id < n) {
+		float sum = 0.0f;
+		for (int i = 0; i < m / TILE; i++)
+			sum += y1[i*n + id];
+		y1[id] = sum;
+	}
+}
+
+__kernel void bicgReduction2(int m, int n, __global float *y2) {
+	int id = get_global_id(0);
+	if (id < m) {
+		float sum = 0.0f;
+		for (int i = 0; i < n / ROWS_PROCESSED; i++)
+			sum += y2[i*m + id];
+		y2[id] = sum;
+	}
+}
+
+__kernel void bicgFused(__global float *A, __global float *x1, __global float *y1, __global float *x2, __global float *y2, int m, int n)
+{
+	int tx = get_local_id(0);
+	int ty = get_local_id(1);
+	int bx = get_group_id(0);
+	int by = get_group_id(1);
+
+//#if USE_SHARED_MATRIX == 1
+	__local float s_A[TILE][TILE + 1];
+//#endif
+#if USE_SHARED_VECTOR_1 == 1
+	__local float s_x1[TILE];
+#endif // USE_SHARED_VECTOR_1
+#if USE_SHARED_VECTOR_2 == 1
+	__local float s_x2[TILE];
+#endif // USE_SHARED_VECTOR_2
+
+	float l_sum = 0.0f;
+
+	// load x1
+#if USE_SHARED_VECTOR_1 == 1
+	if (ty == 0)
+		s_x1[tx] = x1[bx * TILE + tx];
+#endif // USE_SHARED_VECTOR_1
+
+#pragma unroll 1
+	for (int i = ROWS_PROCESSED*by; i < ROWS_PROCESSED*(by + 1); i += TILE) {
+
+		// load x2
+#if USE_SHARED_VECTOR_2 == 1
+		if (ty == 1) {
+			s_x2[tx] = x2[i + tx];
+		}
+#endif // USE_SHARED_VECTOR_2
+#if USE_SHARED_MATRIX == 1 || USE_SHARED_VECTOR_2 == 1
+		barrier(CLK_LOCAL_MEM_FENCE);
+#endif
+// multiply x2
+#if UNROLL_BICG_STEP == 1
+#pragma unroll
+#endif
+		for (int j = 0; j < TILE; j += BICG_STEP) {
+#if USE_SHARED_MATRIX == 1
+			s_A[ty + j][tx] = A[(i + ty + j)*m + bx * TILE + tx];
+	#if USE_SHARED_VECTOR_2 == 1
+			l_sum += s_A[ty + j][tx] * s_x2[ty + j];
+	#else
+			l_sum += s_A[ty + j][tx] * x2[i + ty + j];
+	#endif // USE_SHARED_VECTOR_2
+#else
+	#if USE_SHARED_VECTOR_2 == 1
+			l_sum += A[(i + ty + j)*m + bx * TILE + tx] * s_x2[ty + j];
+	#else
+			l_sum += A[(i + ty + j)*m + bx * TILE + tx] * x2[i + ty + j];
+	#endif // USE_SHARED_VECTOR_2
+#endif // USE_SHARED_MATRIX
+		}
+
+		barrier(CLK_LOCAL_MEM_FENCE);
+		float tmp = 0.0f;
+
+// multiply x1
+#if UNROLL_BICG_STEP == 1
+#pragma unroll
+#endif
+		for (int j = 0; j < TILE; j += BICG_STEP)
+#if USE_SHARED_MATRIX == 1
+	#if USE_SHARED_VECTOR_1 == 1
+			tmp += s_A[tx][ty + j] * s_x1[ty + j];
+	#else
+			tmp += s_A[tx][ty + j] * x1[bx*TILE + ty + j];
+	#endif // USE_SHARED_VECTOR_1
+#else
+	#if USE_SHARED_VECTOR_1 == 1
+			tmp += A[(i + tx)*m + bx * TILE + ty + j] * s_x1[ty + j];
+	#else
+			tmp += A[(i + tx)*m + bx * TILE + ty + j] * x1[bx*TILE + ty + j];
+	#endif // USE_SHARED_VECTOR_1
+#endif // USE_SHARED_MATRIX
+
+#if USE_SHARED_REDUCTION_1 == 1
+		s_A[tx][ty] = tmp;
+		barrier(CLK_LOCAL_MEM_FENCE);
+#else
+		A[(i + tx)*m + bx * TILE + ty] = tmp;
+		barrier(CLK_GLOBAL_MEM_FENCE);
+#endif
+
+#if BICG_BATCH <= 1
+		if (ty < TILE / 2)
+	#if USE_SHARED_REDUCTION_1 == 1
+			s_A[tx][ty] = tmp = tmp + s_A[tx][ty + TILE / 2];
+		barrier(CLK_LOCAL_MEM_FENCE);
+	#else
+			A[(i + tx)*m + bx * TILE + ty] = tmp = tmp + A[(i + tx)*m + bx * TILE + ty + TILE / 2];
+		barrier(CLK_GLOBAL_MEM_FENCE);
+	#endif // USE_SHARED_REDUCTION_1
+#endif // BICG_BATCH
+
+#if BICG_BATCH <= 2
+		if (ty < TILE / 4)
+	#if USE_SHARED_REDUCTION_1 == 1
+			s_A[tx][ty] = tmp = tmp + s_A[tx][ty + TILE / 4];
+		barrier(CLK_LOCAL_MEM_FENCE);
+	#else
+			A[(i + tx)*m + bx * TILE + ty] = tmp = tmp + A[(i + tx)*m + bx * TILE + ty + TILE / 4];
+		barrier(CLK_GLOBAL_MEM_FENCE);
+	#endif // USE_SHARED_REDUCTION_1
+#endif // BICG_BATCH
+
+#if BICG_BATCH <= 4
+		if (ty < TILE / 8)
+	#if USE_SHARED_REDUCTION_1 == 1
+			s_A[tx][ty] = tmp = tmp + s_A[tx][ty + TILE / 8];
+		barrier(CLK_LOCAL_MEM_FENCE);
+	#else
+			A[(i + tx)*m + bx * TILE + ty] = tmp = tmp + A[(i + tx)*m + bx * TILE + ty + TILE / 8];
+		barrier(CLK_GLOBAL_MEM_FENCE);
+	#endif // USE_SHARED_REDUCTION_1
+#endif // BICG_BATCH
+
+#if BICG_BATCH <= 8 && TILE >= 32
+		if (ty < TILE / 16)
+	#if USE_SHARED_REDUCTION_1 == 1
+			s_A[tx][ty] = tmp = tmp + s_A[tx][ty + TILE / 16];
+		barrier(CLK_LOCAL_MEM_FENCE);
+	#else
+			A[(i + tx)*m + bx * TILE + ty] = tmp = tmp + A[(i + tx)*m + bx * TILE + ty + TILE / 16];
+		barrier(CLK_GLOBAL_MEM_FENCE);
+	#endif // USE_SHARED_REDUCTION_1
+#endif // BICG_BATCH
+
+#if TILE >= 64
+		if (ty < TILE / 32)
+	#if USE_SHARED_REDUCTION_1 == 1
+			s_A[tx][ty] = tmp = tmp + s_A[tx][ty + TILE / 32];
+		barrier(CLK_LOCAL_MEM_FENCE);
+	#else
+			A[(i + tx)*m + bx * TILE + ty] = tmp = tmp + A[(i + tx)*m + bx * TILE + ty + TILE / 32];
+		barrier(CLK_GLOBAL_MEM_FENCE);
+	#endif // USE_SHARED_REDUCTION_1
+#endif // BICG_BATCH
+
+		if (ty == 0) {
+#if ATOMICS == 1
+	#if USE_SHARED_REDUCTION_1 == 1
+			atomicAdd_g_f(y1 + i + tx, tmp + s_A[tx][1]);
+	#else
+			atomicAdd_g_f(y1 + i + tx, tmp + A[(i + tx)*m + bx * TILE + 1]);
+	#endif // USE_SHARED_REDUCTION_1
+#else // reduced later in bicgReduction1
+	#if USE_SHARED_REDUCTION_1 == 1
+			y1[i + tx + bx*n] = tmp + s_A[tx][1];
+	#else
+			y1[i + tx + bx*n] = tmp + A[(i + tx)*m + bx * TILE + 1];
+	#endif // USE_SHARED_REDUCTION_1
+#endif // ATOMICS
+		}
+	}
+
+	// compute total sum
+	barrier(CLK_LOCAL_MEM_FENCE);
+#if USE_SHARED_REDUCTION_2 == 1
+	s_A[ty][tx] = l_sum;
+#else
+	A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty)*m + bx * TILE + tx] = l_sum;
+#endif // USE_SHARED_REDUCTION_2
+
+#if BICG_BATCH <= 1
+	barrier_sh_red();
+	if (ty < TILE / 2)
+	#if USE_SHARED_REDUCTION_2 == 1
+		s_A[ty][tx] = l_sum = l_sum + s_A[ty + TILE / 2][tx];
+	#else
+		A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty)*m + bx * TILE + tx] = l_sum = l_sum + A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty + TILE / 2)*m + bx * TILE + tx];
+	#endif // USE_SHARED_REDUCTION_2
+#endif // BICG_BATCH
+
+#if BICG_BATCH <= 2
+	barrier_sh_red();
+	if (ty < TILE / 4)
+	#if USE_SHARED_REDUCTION_2 == 1
+		s_A[ty][tx] = l_sum = l_sum + s_A[ty + TILE / 4][tx];
+	#else
+		A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty)*m + bx * TILE + tx] = l_sum = l_sum + A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty + TILE / 4)*m + bx * TILE + tx];
+	#endif // USE_SHARED_REDUCTION_2
+#endif // BICG_BATCH
+
+#if BICG_BATCH <= 4
+	barrier_sh_red();
+	if (ty < TILE / 8)
+	#if USE_SHARED_REDUCTION_2 == 1
+		s_A[ty][tx] = l_sum = l_sum + s_A[ty + TILE / 8][tx];
+	#else
+		A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty)*m + bx * TILE + tx] = l_sum = l_sum + A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty + TILE / 8)*m + bx * TILE + tx];
+	#endif // USE_SHARED_REDUCTION_2
+#endif // BICG_BATCH
+
+#if BICG_BATCH <= 8 && TILE >= 32
+	barrier_sh_red();
+	if (ty < TILE / 16)
+	#if USE_SHARED_REDUCTION_2 == 1
+		s_A[ty][tx] = l_sum = l_sum + s_A[ty + TILE / 16][tx];
+	#else
+		A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty)*m + bx * TILE + tx] = l_sum = l_sum + A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty + TILE / 16)*m + bx * TILE + tx];
+	#endif // USE_SHARED_REDUCTION_2
+#endif // BICG_BATCH
+
+#if TILE >= 64
+	barrier_sh_red();
+	if (ty < TILE / 32)
+	#if USE_SHARED_REDUCTION_2 == 1
+		s_A[ty][tx] = l_sum = l_sum + s_A[ty + TILE / 32][tx];
+	#else
+		A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty)*m + bx * TILE + tx] = l_sum = l_sum + A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + ty + TILE / 32)*m + bx * TILE + tx];
+	#endif // USE_SHARED_REDUCTION_2
+#endif // BICG_BATCH
+
+	barrier_sh_red();
+	if (ty == 0)
+#if ATOMICS == 1
+	#if USE_SHARED_REDUCTION_2 == 1
+		atomicAdd_g_f(y2 + bx * TILE + tx, l_sum + s_A[1][tx]);
+	#else
+		atomicAdd_g_f(y2 + bx * TILE + tx, l_sum + A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + 1)*m + bx * TILE + tx]);
+	#endif // USE_SHARED_REDUCTION_2
+#else // reduced later in bicgReduction2
+	#if USE_SHARED_REDUCTION_2 == 1
+		y2[bx * TILE + tx + by*m] = l_sum + s_A[1][tx];
+	#else
+		y2[bx * TILE + tx + by*m] = l_sum + A[(ROWS_PROCESSED*by + ROWS_PROCESSED - TILE + 1)*m + bx * TILE + tx];
+	#endif // USE_SHARED_REDUCTION_2
+#endif // ATOMICS
+}
+

--- a/examples/bicg/bicg_reference_kernel.cl
+++ b/examples/bicg/bicg_reference_kernel.cl
@@ -1,0 +1,126 @@
+/**
+ * bicg.cl: This file is part of the PolyBench/GPU 1.0 test suite.
+ *
+ *
+ * Contact: Scott Grauer-Gray <sgrauerg@gmail.com>
+ * Louis-Noel Pouchet <pouchet@cse.ohio-state.edu>
+ * Web address: http://www.cse.ohio-state.edu/~pouchet/software/polybench/GPU
+ */
+
+#if defined(cl_khr_fp64)  // Khronos extension available?
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+#elif defined(cl_amd_fp64)  // AMD extension available?
+#pragma OPENCL EXTENSION cl_amd_fp64 : enable
+#endif
+
+ // process BICG_BATCH elements in thread
+#define BICG_BATCH 8
+#define BICG_STEP 32/BICG_BATCH
+
+typedef float DATA_TYPE;
+
+__kernel void bicgKernel1(__global DATA_TYPE *A, __global DATA_TYPE *p, __global DATA_TYPE *q, int m, int n)
+{
+	int i = get_global_id(0);
+
+	if (i < n)
+	{
+		q[i] = 0.0;
+
+		int j;
+		for (j = 0; j < m; j++)
+		{
+			q[i] += A[i * m + j] * p[j];
+		}
+	}
+
+}
+
+__kernel void bicgKernel2(__global DATA_TYPE *A, __global DATA_TYPE *r, __global DATA_TYPE *s, int m, int n)
+{
+	int j = get_global_id(0);
+
+	if (j < m)
+	{
+		s[j] = 0.0;
+
+		int i;
+		for (i = 0; i < n; i++)
+		{
+			s[j] += A[i * m + j] * r[i];
+		}
+	}
+
+}
+
+inline void atomicAdd_g_f(volatile __global float *addr, float val)
+{
+	union {
+		unsigned int u32;
+		float f32;
+	} next, expected, current;
+	current.f32 = *addr;
+	do {
+		expected.f32 = current.f32;
+		next.f32 = expected.f32 + val;
+		current.u32 = atomic_cmpxchg((volatile __global unsigned int *)addr,
+			expected.u32, next.u32);
+	} while (current.u32 != expected.u32);
+}
+
+__kernel void bicgFusedRef(__global float *A, __global float *x1, __global float *y1, __global float *x2, __global float *y2, int m, int n)
+{
+	int tx = get_local_id(0);
+	int ty = get_local_id(1);
+	int bx = get_group_id(0);
+	int by = get_group_id(1);
+	int gy = get_global_size(1);
+
+	__local float s_A[32][33];
+	__local float s_x1[32];
+	__local float s_x2[32];
+
+	float l_sum = 0.0f;
+
+	// load x2
+	if (ty == 0)
+		s_x2[tx] = x2[bx * 32 + tx];
+	for (int i = m*by; i < m*(by + 1); i += 32) {
+		// load x1
+		if (ty == 1)
+			s_x1[tx] = x1[i + tx];
+		barrier(CLK_LOCAL_MEM_FENCE);
+
+		for (int j = 0; j < 32; j += BICG_STEP) {
+			s_A[ty + j][tx] = A[(i + ty + j)*n + bx * 32 + tx];
+			l_sum += s_A[ty + j][tx] * s_x1[ty + j];
+		}
+		barrier(CLK_LOCAL_MEM_FENCE);
+		float tmp = 0.0f;
+
+		for (int j = 0; j < 32; j += BICG_STEP)
+			tmp += s_A[tx][ty + j] * s_x2[ty + j];
+		s_A[tx][ty] = tmp;
+		barrier(CLK_LOCAL_MEM_FENCE);
+
+		if (ty < 2)
+			s_A[tx][ty] = tmp = tmp + s_A[tx][ty + 2];
+		barrier(CLK_LOCAL_MEM_FENCE);
+
+		if (ty == 0) {
+			atomicAdd_g_f(y2 + i + tx, tmp + s_A[tx][1]);
+		}
+	}
+
+	// compute total sum
+	barrier(CLK_LOCAL_MEM_FENCE);
+	s_A[ty][tx] = l_sum;
+	barrier(CLK_LOCAL_MEM_FENCE);
+	if (ty < 2) {
+		s_A[ty][tx] = l_sum = l_sum + s_A[ty + 2][tx];
+	}
+	barrier(CLK_LOCAL_MEM_FENCE);
+	if (ty == 0) {
+		atomicAdd_g_f(y1 + bx * 32 + tx, l_sum + s_A[1][tx]);
+	}
+}

--- a/premake5.lua
+++ b/premake5.lua
@@ -256,6 +256,12 @@ project "nbody_opencl"
     includedirs { "source" }
     links { "ktt" }
 
+project "bicg_opencl"
+    kind "ConsoleApp"
+    files { "examples/bicg/*.cpp", "examples/bicg/*.cl" }
+    includedirs { "source" }
+    links { "ktt" }
+
 project "coulomb_sum_2d_opencl"
     kind "ConsoleApp"
     files { "examples/coulomb_sum_2d/*.cpp", "examples/coulomb_sum_2d/*.cl" }


### PR DESCRIPTION
As a part of my diploma thesis, I am working on some parameterized examples for autotuning with KTT, this is the first one.

In this example, a reference result for vectors `y1` and `y2` is computed on CPU and it is compared to the:

- result from 2 separate kernels from PolyBench suite
- result from fused kernel by @jiri-filipovic which I rewrote to OpenCL (originally in CUDA)
- results from 5120 combinations of parameterized fused kernel

`M` and `N` values can be changed to other powers of 2.

Features: reference class, kernel composition, tuning manipulator, constraints

The example is tested on NVIDIA GeForce GTX 960 and Intel Core i7-3770.