### PR TITLE
To fix missing premake5.lua in #35

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -325,6 +325,12 @@ project "gemm_demo_openclcuda"
     files { "examples/gemm_batch/*.h", "examples/gemm_batch/demo.cpp", "examples/gemm_batch/*.cl", "examples/gemm_batch/*.cu" }
     includedirs { "source" }
     links { "ktt" }
+
+project "sort-new"
+    kind "ConsoleApp"
+    files {"examples/sort-new/*.h", "examples/sort-new/*.cpp", "examples/sort-new/*.cu"}
+    includedirs { "source" }
+    links { "ktt" }
 end -- cuda_projects
 
 end -- _OPTIONS["no-examples"]


### PR DESCRIPTION
Sorry. My git seems to ignore premake5.lua, so the changes in that did not make it into the commit and then pull request #35 . 
Janka