### PR TITLE
Set CUDA architecture option for selected device

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ systems are Linux and Windows.
     
 * Build under Linux (inside KTT root folder):
     - ensure that path to vendor SDK is correctly set in the environment variables
-    - run `./premake5 gmake` to generate makefile
+    - run `premake5 gmake` to generate makefile
     - run `cd build` to get inside build directory
     - afterwards run `make config={configuration}_{architecture}` to build the project (e.g. `make config=release_x86_64`)
     

--- a/docs/classktt_1_1_tuner.html
+++ b/docs/classktt_1_1_tuner.html
@@ -1379,7 +1379,7 @@ template&lt;typename T &gt; </div>
         </tr>
       </table>
 </div><div class="memdoc">
-<p>Sets compute API compiler options to specified options. There are no default options for OpenCL back-end. Default option for CUDA back-end is "--gpu-architecture=compute_30".</p>
+<p>Sets compute API compiler options to specified options. There are no default options for OpenCL back-end. By default for CUDA back-end it adds the compiler option "--gpu-architecture=compute_xx" where `xx` is the compute capability retrieved from the device.</p>
 <p>For list of OpenCL compiler options, see: <a href="https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clBuildProgram.html">https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clBuildProgram.html</a> For list of CUDA compiler options, see: <a href="http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-command-options">http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-command-options</a> </p><dl class="params"><dt>Parameters</dt><dd>
   <table class="params">
     <tr><td class="paramname">options</td><td>Compute API compiler options. If multiple options are used, they need to be separated by a single space character. </td></tr>

--- a/premake5.lua
+++ b/premake5.lua
@@ -279,7 +279,6 @@ project "ktt"
     includedirs { "source" }
     defines { "KTT_LIBRARY" }
     targetname(ktt_library_name)
-    links { "cudart" }
 
     local libraries = false
     
@@ -605,7 +604,6 @@ project "tests"
     files { "tests/**.hpp", "tests/**.cpp", "tests/**.cl", "source/**.h", "source/**.hpp", "source/**.cpp" }
     includedirs { "tests", "source" }
     defines { "KTT_TESTS", "DO_NOT_USE_WMAIN" }
-    links { "cudart" }
     
     if _OPTIONS["no-opencl"] then
         removefiles { "tests/opencl_engine_tests.cpp" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -279,6 +279,7 @@ project "ktt"
     includedirs { "source" }
     defines { "KTT_LIBRARY" }
     targetname(ktt_library_name)
+    links { "cudart" }
 
     local libraries = false
     
@@ -604,6 +605,7 @@ project "tests"
     files { "tests/**.hpp", "tests/**.cpp", "tests/**.cl", "source/**.h", "source/**.hpp", "source/**.cpp" }
     includedirs { "tests", "source" }
     defines { "KTT_TESTS", "DO_NOT_USE_WMAIN" }
+    links { "cudart" }
     
     if _OPTIONS["no-opencl"] then
         removefiles { "tests/opencl_engine_tests.cpp" }

--- a/source/compute_engine/cuda/cuda_engine.cpp
+++ b/source/compute_engine/cuda/cuda_engine.cpp
@@ -5,7 +5,6 @@
 #include <utility/ktt_utility.h>
 #include <utility/logger.h>
 #include <utility/timer.h>
-#include <cuda_runtime_api.h>
 
 #ifdef KTT_PROFILING_CUPTI_LEGACY
 #include <compute_engine/cuda/cupti_legacy/cupti_profiling_subscription.h>
@@ -40,8 +39,8 @@ CUDAEngine::CUDAEngine(const DeviceIndex deviceIndex, const uint32_t queueCount)
     // Set the GPU architecture for the CUDA device
     int computeCapabilityMajor = 0;
     int computeCapabilityMinor = 0;
-    cudaDeviceGetAttribute(&computeCapabilityMajor, cudaDevAttrComputeCapabilityMajor, deviceIndex);
-    cudaDeviceGetAttribute(&computeCapabilityMinor, cudaDevAttrComputeCapabilityMinor, deviceIndex);
+    cuDeviceGetAttribute(&computeCapabilityMajor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, deviceIndex);
+    cuDeviceGetAttribute(&computeCapabilityMinor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, deviceIndex);
     std::string gpuArchitecture = std::string("--gpu-architecture=compute_") + std::to_string(computeCapabilityMajor) + std::to_string(computeCapabilityMinor);
     setCompilerOptions(gpuArchitecture);
 

--- a/source/compute_engine/cuda/cuda_engine.cpp
+++ b/source/compute_engine/cuda/cuda_engine.cpp
@@ -39,8 +39,8 @@ CUDAEngine::CUDAEngine(const DeviceIndex deviceIndex, const uint32_t queueCount)
     // Set the GPU architecture for the CUDA device
     int computeCapabilityMajor = 0;
     int computeCapabilityMinor = 0;
-    cuDeviceGetAttribute(&computeCapabilityMajor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, deviceIndex);
-    cuDeviceGetAttribute(&computeCapabilityMinor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, deviceIndex);
+    checkCUDAError(cuDeviceGetAttribute(&computeCapabilityMajor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, context->getDevice()), "cuDeviceGetAttribute");
+    checkCUDAError(cuDeviceGetAttribute(&computeCapabilityMinor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, context->getDevice()), "cuDeviceGetAttribute");
     std::string gpuArchitecture = std::string("--gpu-architecture=compute_") + std::to_string(computeCapabilityMajor) + std::to_string(computeCapabilityMinor);
     setCompilerOptions(gpuArchitecture);
 

--- a/source/tuner_api.h
+++ b/source/tuner_api.h
@@ -615,8 +615,8 @@ public:
     void setArgumentComparator(const ArgumentId id, const std::function<bool(const void*, const void*)>& comparator);
 
     /** @fn void setCompilerOptions(const std::string& options)
-      * Sets compute API compiler options to specified options. There are no default options for OpenCL back-end. Default option for CUDA
-      * back-end is "--gpu-architecture=compute_30".
+      * Sets compute API compiler options to specified options. There are no default options for OpenCL back-end. By default for CUDA back-end it adds the
+      * compiler option "--gpu-architecture=compute_xx", where `xx` is the compute capability retrieved from the device.
       * 
       * For list of OpenCL compiler options, see: https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clBuildProgram.html
       * For list of CUDA compiler options, see: http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-command-options


### PR DESCRIPTION
This replaces the default compiler option `--gpu-architecture=compute_30` with retrieved compute capability versions from the selected device.

Also removed the `./` from the `premake5` command to reflect whats actually used.