### PR TITLE
Little refactoring of sort-new example

### DIFF
--- a/examples/sort-new/sort_kernel.cl
+++ b/examples/sort-new/sort_kernel.cl
@@ -1,6 +1,10 @@
 // This kernel code based on CUDPP.  Please see the notice in
 // LICENSE_CUDPP.txt.
 
+//This kernel segfaults when run on CPU. The segfault occurrs in findRadixOffsets and it looks like a serious memory corruption. Incredibly frustrating to debug, even adding printf can trigger segfault. Maybe a bug we have unknowingly adopted from SHOC?
+
+//Works just fine when run on GPU.
+
 #if SORT_VECTOR == 2
 #define SORTVECTYPE uint2
 #elif SORT_VECTOR == 4

--- a/examples/sort-new/sort_tunable.h
+++ b/examples/sort-new/sort_tunable.h
@@ -45,10 +45,6 @@ class TunableSort : public ktt::TuningManipulator {
       fullBlockId(fullBlockId),
       storeSumId(storeSumId)
     {
-      keysOut = std::vector<uint>(size);
-      valuesOut = std::vector<uint>(size);
-      keysIn = std::vector<uint>(size);
-      valuesIn = std::vector<uint>(size);
     }
 
     // Run the code with kernels
@@ -183,12 +179,8 @@ void scanArrayRecursive(std::vector<uint> &outArray, std::vector<uint> &inArray,
     int size;
     ktt::ArgumentId keysOutId;
     ktt::ArgumentId valuesOutId;
-    std::vector<uint> keysOut;
-    std::vector<uint> valuesOut;
     ktt::ArgumentId keysInId;
     ktt::ArgumentId valuesInId;
-    std::vector<uint> keysIn;
-    std::vector<uint> valuesIn;
     ktt::ArgumentId scanNumBlocksId;
     ktt::ArgumentId countersId;
     ktt::ArgumentId counterSumsId;


### PR DESCRIPTION
Hi,

this is just two small commits regarding sort-new example:
- getting rid of unused variables 
- adding a comment warning that the OpenCL version does not run on CPU due to segfault. There is a really weird situation, probably some seriously corrupted memory. On GPU it runs fine. As far as we know, we probably adopted some bug from shoc benchmark. Extremely frustrating to debug, postponing that to the future. 

Thanks,
Janka